### PR TITLE
Fix for compound messages containing >255 messages or messages > 64KB

### DIFF
--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -1200,9 +1200,9 @@ func TestMemberlist_UserData(t *testing.T) {
 
 	bindPort := m1.config.BindPort
 
-	bcasts := [][]byte{
-		[]byte("test"),
-		[]byte("foobar"),
+	bcasts := make([][]byte, 256)
+	for i := range bcasts {
+		bcasts[i] = []byte(fmt.Sprintf("%d", i))
 	}
 
 	// Create a second node

--- a/net.go
+++ b/net.go
@@ -739,11 +739,17 @@ func (m *Memberlist) sendMsg(a Address, msg []byte) error {
 	msgs = append(msgs, msg)
 	msgs = append(msgs, extra...)
 
-	// Create a compound message
-	compound := makeCompoundMessage(msgs)
+	// Create one or more compound messages.
+	compounds := makeCompoundMessages(msgs)
 
-	// Send the message
-	return m.rawSendMsgPacket(a, nil, compound.Bytes())
+	// Send the messages.
+	for _, compound := range compounds {
+		if err := m.rawSendMsgPacket(a, nil, compound.Bytes()); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // rawSendMsgPacket is used to send message via packet to another host without

--- a/state.go
+++ b/state.go
@@ -606,10 +606,12 @@ func (m *Memberlist) gossip() {
 				m.logger.Printf("[ERR] memberlist: Failed to send gossip to %s: %s", addr, err)
 			}
 		} else {
-			// Otherwise create and send a compound message
-			compound := makeCompoundMessage(msgs)
-			if err := m.rawSendMsgPacket(node.FullAddress(), &node, compound.Bytes()); err != nil {
-				m.logger.Printf("[ERR] memberlist: Failed to send gossip to %s: %s", addr, err)
+			// Otherwise create and send one or more compound messages
+			compounds := makeCompoundMessages(msgs)
+			for _, compound := range compounds {
+				if err := m.rawSendMsgPacket(node.FullAddress(), &node, compound.Bytes()); err != nil {
+					m.logger.Printf("[ERR] memberlist: Failed to send gossip to %s: %s", addr, err)
+				}
 			}
 		}
 	}

--- a/util.go
+++ b/util.go
@@ -152,6 +152,23 @@ OUTER:
 	return kNodes
 }
 
+// makeCompoundMessages takes a list of messages and packs
+// them into one or multiple messages based on the limitations
+// of compound messages (255 messages each).
+func makeCompoundMessages(msgs [][]byte) []*bytes.Buffer {
+	const maxMsgs = 255
+	bufs := make([]*bytes.Buffer, 0, (len(msgs)+(maxMsgs-1))/maxMsgs)
+
+	for ; len(msgs) > maxMsgs; msgs = msgs[maxMsgs:] {
+		bufs = append(bufs, makeCompoundMessage(msgs[:maxMsgs]))
+	}
+	if len(msgs) > 0 {
+		bufs = append(bufs, makeCompoundMessage(msgs))
+	}
+
+	return bufs
+}
+
 // makeCompoundMessage takes a list of messages and generates
 // a single compound message containing all of them
 func makeCompoundMessage(msgs [][]byte) *bytes.Buffer {

--- a/util.go
+++ b/util.go
@@ -154,11 +154,37 @@ OUTER:
 
 // makeCompoundMessages takes a list of messages and packs
 // them into one or multiple messages based on the limitations
-// of compound messages (255 messages each).
+// of compound messages (255 messages each, 64KB max message size).
+//
+// The input msgs can be modified in-place.
 func makeCompoundMessages(msgs [][]byte) []*bytes.Buffer {
-	const maxMsgs = 255
+	const (
+		maxMsgs      = math.MaxUint8
+		maxMsgLength = math.MaxUint16
+	)
+
+	// Optimistically assume there will be no big message.
 	bufs := make([]*bytes.Buffer, 0, (len(msgs)+(maxMsgs-1))/maxMsgs)
 
+	// Do not add to a compound message any message bigger than the max message length
+	// we can store.
+	r, w := 0, 0
+	for r < len(msgs) {
+		if len(msgs[r]) <= maxMsgLength {
+			// Keep it.
+			msgs[w] = msgs[r]
+			r++
+			w++
+			continue
+		}
+
+		// This message is a large one, so we send it alone.
+		bufs = append(bufs, bytes.NewBuffer(msgs[r]))
+		r++
+	}
+	msgs = msgs[:w]
+
+	// Group remaining messages in compound message(s).
 	for ; len(msgs) > maxMsgs; msgs = msgs[maxMsgs:] {
 		bufs = append(bufs, makeCompoundMessage(msgs[:maxMsgs]))
 	}


### PR DESCRIPTION
In this PR:
- Cherry pick of https://github.com/hashicorp/memberlist/pull/239 against version we're using in GEM
- Do not put in a compound message any message which is > 64KB (because the length is encoded as `uint16`)
- Fix usage of compound messages in `sendMsg()` too
