### PR TITLE
really skip label check by ignoring incoming labels

### DIFF
--- a/net.go
+++ b/net.go
@@ -365,10 +365,6 @@ func (m *Memberlist) ingestPacket(buf []byte, from net.Addr, timestamp time.Time
 	}
 
 	if m.config.SkipInboundLabelCheck {
-		if packetLabel != "" {
-			m.logger.Printf("[ERR] memberlist: unexpected double packet label header: %s", LogAddress(from))
-			return
-		}
 		// Set this from config so that the auth data assertions work below.
 		packetLabel = m.config.Label
 	}

--- a/net.go
+++ b/net.go
@@ -249,10 +249,6 @@ func (m *Memberlist) handleConn(conn net.Conn) {
 	}
 
 	if m.config.SkipInboundLabelCheck {
-		if streamLabel != "" {
-			m.logger.Printf("[ERR] memberlist: unexpected double stream label header: %s", LogConn(conn))
-			return
-		}
 		// Set this from config so that the auth data assertions work below.
 		streamLabel = m.config.Label
 	}


### PR DESCRIPTION
currently the flag `SkipInboundLabelCheck` doesn't really make memberlist skip the label check, because if this flag is enabled and the memberlist client is configured with no label and then it receives a message that has a label then prints a warning and drops the received message. I think if `SkipInboundLabelCheck` is enabled then it shouldn't matter whether incoming messages have a label, at all.