### PR TITLE
Add NodeSelectionDelegate

### DIFF
--- a/config.go
+++ b/config.go
@@ -210,6 +210,7 @@ type Config struct {
 	Merge                   MergeDelegate
 	Ping                    PingDelegate
 	Alive                   AliveDelegate
+	NodeSelection           NodeSelectionDelegate
 
 	// DNSConfigPath points to the system's DNS config file, usually located
 	// at /etc/resolv.conf. It can be overridden via config for easier testing.

--- a/node_selection_delegate.go
+++ b/node_selection_delegate.go
@@ -3,8 +3,8 @@
 package memberlist
 
 // NodeSelectionDelegate is an optional delegate that can be used to filter and prioritize
-// nodes for gossip, probing, and push/pull operations. This allows implementing custom
-// routing logic, such as zone-aware or rack-aware gossiping.
+// nodes for gossip, and push/pull operations. This allows implementing custom routing logic,
+// such as zone-aware or rack-aware gossiping.
 type NodeSelectionDelegate interface {
 	// SelectNode is called for each node to determine:
 	// - selected: whether the node should be included in the selection pool

--- a/node_selection_delegate.go
+++ b/node_selection_delegate.go
@@ -8,6 +8,9 @@ package memberlist
 type NodeSelectionDelegate interface {
 	// SelectNode is called for each node to determine:
 	// - selected: whether the node should be included in the selection pool
-	// - preferred: whether the node should be prioritized (at least one preferred node is selected)
+	// - preferred: indicates whether the node should be prioritized. During a gossip cycle,
+	//              at least one preferred node is always selected. If no preferred nodes exist,
+	//              all gossip targets are chosen randomly from the nodes that have been marked
+	//              as "selected".
 	SelectNode(Node) (selected, preferred bool)
 }

--- a/node_selection_delegate.go
+++ b/node_selection_delegate.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package memberlist
+
+// NodeSelectionDelegate is an optional delegate that can be used to filter and prioritize
+// nodes for gossip, probing, and push/pull operations. This allows implementing custom
+// routing logic, such as zone-aware or rack-aware gossiping.
+type NodeSelectionDelegate interface {
+	// SelectNode is called for each node to determine:
+	// - selected: whether the node should be included in the selection pool
+	// - preferred: whether the node should be prioritized (at least one preferred node is selected)
+	SelectNode(Node) (selected, preferred bool)
+}

--- a/node_selection_delegate.go
+++ b/node_selection_delegate.go
@@ -5,6 +5,9 @@ package memberlist
 // NodeSelectionDelegate is an optional delegate that can be used to filter and prioritize
 // nodes for gossip, and push/pull operations. This allows implementing custom routing logic,
 // such as zone-aware or rack-aware gossiping.
+//
+// This delegate is not used for probes (health checks). When implementing zone-aware gossiping,
+// probes can bypass this delegate.
 type NodeSelectionDelegate interface {
 	// SelectNode is called for each node to determine:
 	// - selected: whether the node should be included in the selection pool

--- a/state.go
+++ b/state.go
@@ -416,7 +416,7 @@ func (m *Memberlist) probeNode(node *nodeState) {
 HANDLE_REMOTE_FAILURE:
 	// Get some random live nodes.
 	m.nodeLock.RLock()
-	kNodes := kRandomNodes(m.config.IndirectChecks, m.nodes, func(n *nodeState) bool {
+	kNodes := kRandomNodes(m.config.IndirectChecks, m.nodes, m.config.NodeSelection, func(n *nodeState) bool {
 		return n.Name == m.config.Name ||
 			n.Name == node.Name ||
 			n.State != StateAlive
@@ -592,7 +592,7 @@ func (m *Memberlist) gossip() {
 
 	// Get some random live, suspect, or recently dead nodes
 	m.nodeLock.RLock()
-	kNodes := kRandomNodes(m.config.GossipNodes, m.nodes, func(n *nodeState) bool {
+	kNodes := kRandomNodes(m.config.GossipNodes, m.nodes, m.config.NodeSelection, func(n *nodeState) bool {
 		if n.Name == m.config.Name {
 			return true
 		}
@@ -648,7 +648,7 @@ func (m *Memberlist) gossip() {
 func (m *Memberlist) pushPull() {
 	// Get a random live node
 	m.nodeLock.RLock()
-	nodes := kRandomNodes(1, m.nodes, func(n *nodeState) bool {
+	nodes := kRandomNodes(1, m.nodes, m.config.NodeSelection, func(n *nodeState) bool {
 		return n.Name == m.config.Name ||
 			n.State != StateAlive
 	})

--- a/state.go
+++ b/state.go
@@ -415,8 +415,10 @@ func (m *Memberlist) probeNode(node *nodeState) {
 
 HANDLE_REMOTE_FAILURE:
 	// Get some random live nodes.
+	// We intentionally don't use the node selector here for now, because we don't want to limit
+	// indirect probes. We may reconsider this in the future.
 	m.nodeLock.RLock()
-	kNodes := kRandomNodes(m.config.IndirectChecks, m.nodes, m.config.NodeSelection, func(n *nodeState) bool {
+	kNodes := kRandomNodes(m.config.IndirectChecks, m.nodes, nil, func(n *nodeState) bool {
 		return n.Name == m.config.Name ||
 			n.Name == node.Name ||
 			n.State != StateAlive

--- a/util.go
+++ b/util.go
@@ -127,9 +127,49 @@ func moveDeadNodes(nodes []*nodeState, gossipToTheDeadTime time.Duration) int {
 // kRandomNodes is used to select up to k random Nodes, excluding any nodes where
 // the exclude function returns true. It is possible that less than k nodes are
 // returned.
-func kRandomNodes(k int, nodes []*nodeState, exclude func(*nodeState) bool) []Node {
-	n := len(nodes)
+func kRandomNodes(k int, nodes []*nodeState, delegate NodeSelectionDelegate, exclude func(*nodeState) bool) []Node {
+	var preferredNodes []*nodeState
+
+	// Filter the nodes using the delegate. This allows downstream projects
+	// to implement custom routing logics (e.g. zone-aware gossiping).
+	if delegate != nil {
+		filteredNodes := make([]*nodeState, 0, len(nodes))
+
+		for _, node := range nodes {
+			selected, preferred := delegate.SelectNode(node.Node)
+			if selected {
+				filteredNodes = append(filteredNodes, node)
+			}
+			if selected && preferred {
+				preferredNodes = append(preferredNodes, node)
+			}
+		}
+
+		nodes = filteredNodes
+	}
+
 	kNodes := make([]Node, 0, k)
+
+	// Select 1 random preferred node first.
+	if n := len(preferredNodes); n > 0 && k > 0 {
+		startIdx := randomOffset(n)
+
+		for i := 0; i < n; i++ {
+			idx := (startIdx + i) % n
+			state := preferredNodes[idx]
+
+			// Ensure it's not excluded by the filter.
+			if exclude != nil && exclude(state) {
+				continue
+			}
+
+			kNodes = append(kNodes, state.Node)
+			break
+		}
+	}
+
+	n := len(nodes)
+
 OUTER:
 	// Probe up to 3*n times, with large n this is not necessary
 	// since k << n, but with small n we want search to be

--- a/util.go
+++ b/util.go
@@ -133,8 +133,9 @@ func kRandomNodes(k int, nodes []*nodeState, delegate NodeSelectionDelegate, exc
 	// Filter the nodes using the delegate. This allows downstream projects
 	// to implement custom routing logics (e.g. zone-aware gossiping).
 	if delegate != nil {
-		filteredNodes := make([]*nodeState, 0, len(nodes))
-		var preferredNodes []*nodeState
+		alloc := make([]*nodeState, 2*len(nodes))
+		filteredNodes := alloc[0:0:len(nodes)]
+		preferredNodes := alloc[len(nodes) : len(nodes) : 2*len(nodes)]
 
 		// Filter nodes by selected ones.
 		for _, node := range nodes {

--- a/util.go
+++ b/util.go
@@ -128,13 +128,15 @@ func moveDeadNodes(nodes []*nodeState, gossipToTheDeadTime time.Duration) int {
 // the exclude function returns true. It is possible that less than k nodes are
 // returned.
 func kRandomNodes(k int, nodes []*nodeState, delegate NodeSelectionDelegate, exclude func(*nodeState) bool) []Node {
-	var preferredNodes []*nodeState
+	kNodes := make([]Node, 0, k)
 
 	// Filter the nodes using the delegate. This allows downstream projects
 	// to implement custom routing logics (e.g. zone-aware gossiping).
 	if delegate != nil {
 		filteredNodes := make([]*nodeState, 0, len(nodes))
+		var preferredNodes []*nodeState
 
+		// Filter nodes by selected ones.
 		for _, node := range nodes {
 			selected, preferred := delegate.SelectNode(node.Node)
 			if selected {
@@ -146,25 +148,23 @@ func kRandomNodes(k int, nodes []*nodeState, delegate NodeSelectionDelegate, exc
 		}
 
 		nodes = filteredNodes
-	}
 
-	kNodes := make([]Node, 0, k)
+		// Select 1 random preferred node first. We guarantee that only 1 preferred node is picked.
+		if n := len(preferredNodes); n > 0 && k > 0 {
+			startIdx := randomOffset(n)
 
-	// Select 1 random preferred node first.
-	if n := len(preferredNodes); n > 0 && k > 0 {
-		startIdx := randomOffset(n)
+			for i := 0; i < n; i++ {
+				idx := (startIdx + i) % n
+				state := preferredNodes[idx]
 
-		for i := 0; i < n; i++ {
-			idx := (startIdx + i) % n
-			state := preferredNodes[idx]
+				// Ensure it's not excluded by the filter.
+				if exclude != nil && exclude(state) {
+					continue
+				}
 
-			// Ensure it's not excluded by the filter.
-			if exclude != nil && exclude(state) {
-				continue
+				kNodes = append(kNodes, state.Node)
+				break
 			}
-
-			kNodes = append(kNodes, state.Node)
-			break
 		}
 	}
 

--- a/util_test.go
+++ b/util_test.go
@@ -329,12 +329,12 @@ func TestKRandomNodesWithDelegate(t *testing.T) {
 			},
 		}
 
-		filterFunc := func(n *nodeState) bool {
+		excludeFunc := func(n *nodeState) bool {
 			return n.State != StateAlive
 		}
 
 		// Request 3 nodes
-		result := kRandomNodes(3, nodes, delegate, filterFunc)
+		result := kRandomNodes(3, nodes, delegate, excludeFunc)
 
 		// Should get up to 3 nodes
 		require.LessOrEqual(t, len(result), 3)

--- a/util_test.go
+++ b/util_test.go
@@ -401,19 +401,7 @@ func TestKRandomNodesWithDelegate(t *testing.T) {
 			return n.State != StateAlive
 		}
 
-		// Count alive nodes
-		aliveCount := 0
-		for _, node := range nodes {
-			if node.State == StateAlive {
-				aliveCount++
-			}
-		}
-
-		// Request exactly as many nodes as there are alive nodes
-		result := kRandomNodes(aliveCount, nodes, delegate, excludeFunc)
-
-		// Should get exactly all alive nodes
-		require.Equal(t, aliveCount, len(result))
+		result := kRandomNodes(len(nodes), nodes, delegate, excludeFunc)
 
 		// Verify all returned nodes are alive
 		for _, node := range result {

--- a/util_test.go
+++ b/util_test.go
@@ -387,6 +387,46 @@ func TestKRandomNodesWithDelegate(t *testing.T) {
 			assert.Equal(t, StateAlive, node.State)
 		}
 	})
+
+	t.Run("all nodes selected and preferred with k equal to node count", func(t *testing.T) {
+		// Create a delegate that marks all alive nodes as both selected and preferred
+		delegate := &testNodeSelectionDelegate{
+			selectFunc: func(n Node) (selected, preferred bool) {
+				// All nodes are both selected and preferred
+				return true, true
+			},
+		}
+
+		excludeFunc := func(n *nodeState) bool {
+			return n.State != StateAlive
+		}
+
+		// Count alive nodes
+		aliveCount := 0
+		for _, node := range nodes {
+			if node.State == StateAlive {
+				aliveCount++
+			}
+		}
+
+		// Request exactly as many nodes as there are alive nodes
+		result := kRandomNodes(aliveCount, nodes, delegate, excludeFunc)
+
+		// Should get exactly all alive nodes
+		require.Equal(t, aliveCount, len(result))
+
+		// Verify all returned nodes are alive
+		for _, node := range result {
+			assert.Equal(t, StateAlive, node.State)
+		}
+
+		// Verify we got all unique nodes (no duplicates)
+		seen := make(map[string]bool)
+		for _, node := range result {
+			assert.False(t, seen[node.Name], "duplicate node: %s", node.Name)
+			seen[node.Name] = true
+		}
+	})
 }
 
 func TestMakeCompoundMessage(t *testing.T) {

--- a/util_test.go
+++ b/util_test.go
@@ -268,9 +268,9 @@ func TestKRandomNodes(t *testing.T) {
 		return false
 	}
 
-	s1 := kRandomNodes(3, nodes, filterFunc)
-	s2 := kRandomNodes(3, nodes, filterFunc)
-	s3 := kRandomNodes(3, nodes, filterFunc)
+	s1 := kRandomNodes(3, nodes, nil, filterFunc)
+	s2 := kRandomNodes(3, nodes, nil, filterFunc)
+	s3 := kRandomNodes(3, nodes, nil, filterFunc)
 
 	if reflect.DeepEqual(s1, s2) {
 		t.Fatalf("unexpected equal")
@@ -295,6 +295,98 @@ func TestKRandomNodes(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestKRandomNodesWithDelegate(t *testing.T) {
+	var nodes []*nodeState
+	for i := 0; i < 20; i++ {
+		state := StateAlive
+		switch i % 3 {
+		case 0:
+			state = StateAlive
+		case 1:
+			state = StateSuspect
+		case 2:
+			state = StateDead
+		}
+		nodes = append(nodes, &nodeState{
+			Node:  Node{Name: fmt.Sprintf("%d", i)},
+			State: state,
+		})
+	}
+
+	t.Run("with preferred nodes", func(t *testing.T) {
+		// Create a delegate that selects nodes 3, 6, 9, 12
+		// and prefers nodes 6 and 12
+		delegate := &testNodeSelectionDelegate{
+			selectFunc: func(n Node) (selected, preferred bool) {
+				switch n.Name {
+				case "3", "6", "9", "12":
+					selected = true
+					preferred = n.Name == "6" || n.Name == "12"
+				}
+				return
+			},
+		}
+
+		filterFunc := func(n *nodeState) bool {
+			return n.State != StateAlive
+		}
+
+		// Request 3 nodes
+		result := kRandomNodes(3, nodes, delegate, filterFunc)
+
+		// Should get up to 3 nodes
+		require.LessOrEqual(t, len(result), 3)
+		require.Greater(t, len(result), 0)
+
+		// At least one should be a preferred node
+		hasPreferred := false
+		for _, node := range result {
+			if node.Name == "6" || node.Name == "12" {
+				hasPreferred = true
+				break
+			}
+		}
+		assert.True(t, hasPreferred)
+
+		// All nodes should be in the selected set
+		for _, node := range result {
+			assert.Contains(t, []string{"3", "6", "9", "12"}, node.Name)
+			assert.Equal(t, StateAlive, node.State)
+		}
+	})
+
+	t.Run("with no preferred nodes", func(t *testing.T) {
+		// Create a delegate that selects nodes 3, 6, 9 but marks none as preferred
+		delegate := &testNodeSelectionDelegate{
+			selectFunc: func(n Node) (selected, preferred bool) {
+				switch n.Name {
+				case "3", "6", "9":
+					selected = true
+					preferred = false
+				}
+				return
+			},
+		}
+
+		filterFunc := func(n *nodeState) bool {
+			return n.State != StateAlive
+		}
+
+		// Request 2 nodes
+		result := kRandomNodes(2, nodes, delegate, filterFunc)
+
+		// Should get up to 2 nodes
+		require.LessOrEqual(t, len(result), 2)
+		require.Greater(t, len(result), 0)
+
+		// All should be in the selected set
+		for _, node := range result {
+			assert.Contains(t, []string{"3", "6", "9"}, node.Name)
+			assert.Equal(t, StateAlive, node.State)
+		}
+	})
 }
 
 func TestMakeCompoundMessage(t *testing.T) {
@@ -387,6 +479,14 @@ func TestCompressDecompressPayload(t *testing.T) {
 	if !reflect.DeepEqual(decomp, []byte("testing")) {
 		t.Fatalf("bad payload: %v", decomp)
 	}
+}
+
+type testNodeSelectionDelegate struct {
+	selectFunc func(Node) (selected, preferred bool)
+}
+
+func (d *testNodeSelectionDelegate) SelectNode(n Node) (selected, preferred bool) {
+	return d.selectFunc(n)
 }
 
 func TestMakeCompoundMessages(t *testing.T) {


### PR DESCRIPTION
I want to build zone-aware gossiping to reduce cross-AZ data transfer. To do it, I need to control what nodes should be selected for gossiping and push/pull. In this PR I propose to introduce a delegate to filter the nodes. The delegate allows to:

- filter nodes
- mark nodes as preferred: at least 1 preferred node is guaranteed to be contacted for each message that should be broadcasted. The idea is to use preferred nodes for bridge members (bridges are the one communicating cross-AZ). The bridges in zone-a will prefer bridges in zone-b, and viceversa.

This PR is draft because I want to get the zone-aware routing working end-to-end (with changes in dskit too) before merging.