### PR TITLE
fix invalid memory address or nil pointer dereference

### DIFF
--- a/net.go
+++ b/net.go
@@ -234,9 +234,10 @@ func (m *Memberlist) streamListen() {
 
 // handleConn handles a single incoming stream connection from the transport.
 func (m *Memberlist) handleConn(conn net.Conn) {
-	defer func() {
+	defer func(conn net.Conn) {
 		_ = conn.Close()
-	}()
+	}(conn) // Capture the original conn, because the code before shadows it.
+
 	m.logger.Printf("[DEBUG] memberlist: Stream connection %s", LogConn(conn))
 
 	metrics.IncrCounterWithLabels([]string{"memberlist", "tcp", "accept"}, 1, m.metricLabels)


### PR DESCRIPTION
This is the fixup for changes in https://github.com/hashicorp/memberlist/pull/325

The `net.Conn` must be captured in the `defer` inside the `handleConn`, so the shadowed variable didn't cause panic, when the error happens inside the `RemoveLabelHeaderFromStream`.

Note, I will open a PR to fix this upstream later.

Relates to https://github.com/grafana/mimir/issues/13287