### PR TITLE
Change NodeSelectionDelegate signature to allow more flexible strategies

### DIFF
--- a/node_selection_delegate.go
+++ b/node_selection_delegate.go
@@ -9,11 +9,12 @@ package memberlist
 // This delegate is not used for probes (health checks). When implementing zone-aware gossiping,
 // probes can bypass this delegate.
 type NodeSelectionDelegate interface {
-	// SelectNode is called for each node to determine:
-	// - selected: whether the node should be included in the selection pool
-	// - preferred: indicates whether the node should be prioritized. During a gossip cycle,
-	//              at least one preferred node is always selected. If no preferred nodes exist,
-	//              all gossip targets are chosen randomly from the nodes that have been marked
-	//              as "selected".
-	SelectNode(Node) (selected, preferred bool)
+	// SelectNodes is called with all candidate nodes to determine:
+	// - selected: the nodes that should be included in the selection pool
+	// - preferred: an optional single node that should be prioritized. During a gossip cycle,
+	//              the preferred node is always selected first if provided. If no preferred
+	//              node is returned, all gossip targets are chosen randomly from the selected nodes.
+	//
+	// The input slice may be modified in place and returned as the selected slice.
+	SelectNodes(nodes []*Node) (selected []*Node, preferred *Node)
 }

--- a/util.go
+++ b/util.go
@@ -130,7 +130,7 @@ func moveDeadNodes(nodes []*nodeState, gossipToTheDeadTime time.Duration) int {
 func kRandomNodes(k int, nodes []*nodeState, delegate NodeSelectionDelegate, exclude func(*nodeState) bool) []Node {
 	kNodes := make([]Node, 0, k)
 
-	// Apply exclude filter first.
+	// Apply the exclude filter first.
 	filteredNodes := make([]*Node, 0, len(nodes))
 	for _, node := range nodes {
 		if exclude != nil && exclude(node) {
@@ -141,11 +141,11 @@ func kRandomNodes(k int, nodes []*nodeState, delegate NodeSelectionDelegate, exc
 
 	// Filter the nodes using the delegate. This allows downstream projects
 	// to implement custom routing logics (e.g. zone-aware routing).
-	var preferred *Node
 	if delegate != nil {
+		var preferred *Node
 		filteredNodes, preferred = delegate.SelectNodes(filteredNodes)
 
-		// Add preferred node first if provided.
+		// Add the preferred node first, if provided.
 		if preferred != nil && k > 0 {
 			kNodes = append(kNodes, *preferred)
 		}


### PR DESCRIPTION
## Description

I want to improve the zone-aware routing implemented in dskit but to do so I need to have the full view over the available nodes when selecting the ones to gossip to. For this reason, in this PR I'm changing `NodeSelectionDelegate` signature to take in input the entire list of nodes, and then filter them, allowing to select 1 (optional) preferred node.

Look at https://github.com/grafana/dskit/pull/800 to see why I need this change.

## Related Issue

N/A