### PR TITLE
Change NodeSelectionDelegate signature to allow more flexible strategies

### DIFF
--- a/memberlist.go
+++ b/memberlist.go
@@ -65,8 +65,8 @@ type Memberlist struct {
 	msgQueueLock         sync.Mutex
 
 	nodeLock   sync.RWMutex
-	nodes      []*nodeState          // Known nodes
-	nodeMap    map[string]*nodeState // Maps Node.Name -> NodeState
+	nodes      []*NodeState          // Known nodes
+	nodeMap    map[string]*NodeState // Maps Node.Name -> NodeState
 	nodeTimers map[string]*suspicion // Maps Node.Name -> suspicion timer
 	awareness  *awareness
 
@@ -214,7 +214,7 @@ func newMemberlist(conf *Config) (*Memberlist, error) {
 		handoffCh:            make(chan struct{}, 1),
 		highPriorityMsgQueue: list.New(),
 		lowPriorityMsgQueue:  list.New(),
-		nodeMap:              make(map[string]*nodeState),
+		nodeMap:              make(map[string]*NodeState),
 		nodeTimers:           make(map[string]*suspicion),
 		awareness:            newAwareness(conf.AwarenessMaxMultiplier, conf.MetricLabels),
 		ackHandlers:          make(map[uint32]*ackHandler),
@@ -774,7 +774,7 @@ func (m *Memberlist) getNodeStateChange(addr string) time.Time {
 	return n.StateChange
 }
 
-func (m *Memberlist) changeNode(addr string, f func(*nodeState)) {
+func (m *Memberlist) changeNode(addr string, f func(*NodeState)) {
 	m.nodeLock.Lock()
 	defer m.nodeLock.Unlock()
 

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -655,10 +655,10 @@ func TestMemberList_Members(t *testing.T) {
 	n3 := &Node{Name: "test3"}
 
 	m := &Memberlist{}
-	nodes := []*nodeState{
-		&nodeState{Node: *n1, State: StateAlive},
-		&nodeState{Node: *n2, State: StateDead},
-		&nodeState{Node: *n3, State: StateSuspect},
+	nodes := []*NodeState{
+		&NodeState{Node: *n1, State: StateAlive},
+		&NodeState{Node: *n2, State: StateDead},
+		&NodeState{Node: *n3, State: StateSuspect},
 	}
 	m.nodes = nodes
 

--- a/net_test.go
+++ b/net_test.go
@@ -516,7 +516,7 @@ func TestTCPPushPull(t *testing.T) {
 		}
 	}()
 
-	m.nodes = append(m.nodes, &nodeState{
+	m.nodes = append(m.nodes, &NodeState{
 		Node: Node{
 			Name: "Test 0",
 			Addr: net.ParseIP(m.config.BindAddr),
@@ -843,7 +843,7 @@ func TestRawSendUdp_CRC(t *testing.T) {
 	}
 
 	// Register a node with PMax >= 5 to be looked up, should result in a checksum
-	m.nodeMap["127.0.0.1"] = &nodeState{
+	m.nodeMap["127.0.0.1"] = &NodeState{
 		Node: Node{PMax: 5},
 	}
 	if err := m.rawSendMsgPacket(a, nil, payload); err != nil {

--- a/node_selection_delegate.go
+++ b/node_selection_delegate.go
@@ -15,7 +15,7 @@ type NodeSelectionDelegate interface {
 	// - preferred: an optional single node that should be prioritized. During a gossip cycle,
 	//              the preferred node is always included if present. If nil, all gossip targets
 	//              are chosen randomly from the selected nodes.
-	//
+	//              It is not necessary to include the preferred node in the selected ones nor to explicitly remove it from them.
 	// The input NodeState slice cannot be manipulated in-place, but if all input nodes are selected
 	// then it's safe to return the input slice as is.
 	//

--- a/node_selection_delegate.go
+++ b/node_selection_delegate.go
@@ -9,11 +9,17 @@ package memberlist
 // This delegate is not used for probes (health checks). When implementing zone-aware gossiping,
 // probes can bypass this delegate.
 type NodeSelectionDelegate interface {
-	// SelectNode is called for each node to determine:
-	// - selected: whether the node should be included in the selection pool
-	// - preferred: indicates whether the node should be prioritized. During a gossip cycle,
-	//              at least one preferred node is always selected. If no preferred nodes exist,
-	//              all gossip targets are chosen randomly from the nodes that have been marked
-	//              as "selected".
-	SelectNode(Node) (selected, preferred bool)
+	// SelectNodes filters and prioritizes nodes for selection. It receives all candidate nodes
+	// and returns:
+	// - selected: the nodes that should be included in the selection pool
+	// - preferred: an optional single node that should be prioritized. During a gossip cycle,
+	//              the preferred node is always included if present. If nil, all gossip targets
+	//              are chosen randomly from the selected nodes.
+	//
+	// The input NodeState slice cannot be manipulated in-place, but if all input nodes are selected
+	// then it's safe to return the input slice as is.
+	//
+	// It's not required for the preferred node to be included in the selected slice. The preferred
+	// node would be picked anyway.
+	SelectNodes([]*NodeState) (selected []*NodeState, preferred *NodeState)
 }

--- a/state.go
+++ b/state.go
@@ -76,7 +76,7 @@ func (n *Node) String() string {
 }
 
 // NodeState is used to manage our state view of another node
-type nodeState struct {
+type NodeState struct {
 	Node
 	Incarnation uint32        // Last known incarnation number
 	State       NodeStateType // Current state
@@ -85,17 +85,17 @@ type nodeState struct {
 
 // Address returns the host:port form of a node's address, suitable for use
 // with a transport.
-func (n *nodeState) Address() string {
+func (n *NodeState) Address() string {
 	return n.Node.Address()
 }
 
 // FullAddress returns the node name and host:port form of a node's address,
 // suitable for use with a transport.
-func (n *nodeState) FullAddress() Address {
+func (n *NodeState) FullAddress() Address {
 	return n.Node.FullAddress()
 }
 
-func (n *nodeState) DeadOrLeft() bool {
+func (n *NodeState) DeadOrLeft() bool {
 	return n.State == StateDead || n.State == StateLeft
 }
 
@@ -302,7 +302,7 @@ func failedRemote(err error) bool {
 }
 
 // probeNode handles a single round of failure checking on a node.
-func (m *Memberlist) probeNode(node *nodeState) {
+func (m *Memberlist) probeNode(node *NodeState) {
 	defer metrics.MeasureSinceWithLabels([]string{"memberlist", "probeNode"}, time.Now(), m.metricLabels)
 
 	// We use our health awareness to scale the overall probe interval, so we
@@ -418,7 +418,7 @@ HANDLE_REMOTE_FAILURE:
 	// We intentionally don't use the node selector here for now, because we don't want to limit
 	// indirect probes. We may reconsider this in the future.
 	m.nodeLock.RLock()
-	kNodes := kRandomNodes(m.config.IndirectChecks, m.nodes, nil, func(n *nodeState) bool {
+	kNodes := kRandomNodes(m.config.IndirectChecks, m.nodes, nil, func(n *NodeState) bool {
 		return n.Name == m.config.Name ||
 			n.Name == node.Name ||
 			n.State != StateAlive
@@ -594,7 +594,7 @@ func (m *Memberlist) gossip() {
 
 	// Get some random live, suspect, or recently dead nodes
 	m.nodeLock.RLock()
-	kNodes := kRandomNodes(m.config.GossipNodes, m.nodes, m.config.NodeSelection, func(n *nodeState) bool {
+	kNodes := kRandomNodes(m.config.GossipNodes, m.nodes, m.config.NodeSelection, func(n *NodeState) bool {
 		if n.Name == m.config.Name {
 			return true
 		}
@@ -656,7 +656,7 @@ func (m *Memberlist) pushPull() {
 
 	// Get random live nodes
 	m.nodeLock.RLock()
-	nodes := kRandomNodes(numNodes, m.nodes, m.config.NodeSelection, func(n *nodeState) bool {
+	nodes := kRandomNodes(numNodes, m.nodes, m.config.NodeSelection, func(n *NodeState) bool {
 		return n.Name == m.config.Name ||
 			n.State != StateAlive
 	})
@@ -921,7 +921,7 @@ func (m *Memberlist) invokeNackHandler(nack nackResp) {
 // accusedInc value, or you can supply 0 to just get the next incarnation number.
 // This alters the node state that's passed in so this MUST be called while the
 // nodeLock is held.
-func (m *Memberlist) refute(me *nodeState, accusedInc uint32) {
+func (m *Memberlist) refute(me *NodeState, accusedInc uint32) {
 	// Make sure the incarnation number beats the accusation.
 	inc := m.nextIncarnation()
 	if accusedInc >= inc {
@@ -1010,7 +1010,7 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 			m.logger.Printf("[WARN] memberlist: Rejected node %s (%v): %s", a.Node, net.IP(a.Addr), errCon)
 			return
 		}
-		state = &nodeState{
+		state = &NodeState{
 			Node: Node{
 				Name: a.Node,
 				Addr: a.Addr,

--- a/state_test.go
+++ b/state_test.go
@@ -1727,7 +1727,7 @@ func TestMemberList_SuspectNode(t *testing.T) {
 	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a, nil, false)
 
-	m.changeNode("test", func(state *nodeState) {
+	m.changeNode("test", func(state *NodeState) {
 		state.StateChange = state.StateChange.Add(-time.Hour)
 	})
 
@@ -2664,9 +2664,9 @@ func testVerifyProtocolSingle(t *testing.T, A [][6]uint8, B [][6]uint8, expect b
 		}
 	}()
 
-	m.nodes = make([]*nodeState, len(A))
+	m.nodes = make([]*NodeState, len(A))
 	for i, n := range A {
-		m.nodes[i] = &nodeState{
+		m.nodes[i] = &NodeState{
 			Node: Node{
 				PMin: n[0],
 				PMax: n[1],


### PR DESCRIPTION
## Description

I want to improve the zone-aware routing implemented in dskit but to do so I need to have the full view over the available nodes when selecting the ones to gossip to. For this reason, in this PR I'm changing `NodeSelectionDelegate` signature to take in input the entire list of nodes, and then filter them, allowing to select 1 (optional) preferred node.

To avoid introducing a performance regression when there's no delegate, I decided to expose `NodeState` ([here](https://github.com/grafana/memberlist/pull/12) I attempted another approach without exposing it, but it was introducing a perf regression in `kRandomNodes()` when there was no delegate or the delegate was a no-op).

In this PR, `kRandomNodes()` is still blazing fast:

```
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/memberlist
cpu: Apple M3 Pro
BenchmarkKRandomNodes/without_delegate-11         	 9570109	       109.4 ns/op	     288 B/op	       1 allocs/op
BenchmarkKRandomNodes/without_delegate-11         	10710229	       109.7 ns/op	     288 B/op	       1 allocs/op
BenchmarkKRandomNodes/without_delegate-11         	10996206	       109.7 ns/op	     288 B/op	       1 allocs/op
BenchmarkKRandomNodes/without_delegate-11         	10831244	       110.0 ns/op	     288 B/op	       1 allocs/op
BenchmarkKRandomNodes/without_delegate-11         	10894020	       108.6 ns/op	     288 B/op	       1 allocs/op
BenchmarkKRandomNodes/without_delegate-11         	11064045	       108.4 ns/op	     288 B/op	       1 allocs/op
BenchmarkKRandomNodes/with_delegate-11            	12300616	        97.49 ns/op	     288 B/op	       1 allocs/op
BenchmarkKRandomNodes/with_delegate-11            	12155103	        97.97 ns/op	     288 B/op	       1 allocs/op
BenchmarkKRandomNodes/with_delegate-11            	11920869	        99.25 ns/op	     288 B/op	       1 allocs/op
BenchmarkKRandomNodes/with_delegate-11            	12310774	        99.01 ns/op	     288 B/op	       1 allocs/op
BenchmarkKRandomNodes/with_delegate-11            	12070784	        98.64 ns/op	     288 B/op	       1 allocs/op
BenchmarkKRandomNodes/with_delegate-11            	11979469	       152.2 ns/op	     288 B/op	       1 allocs/op
PASS
ok  	github.com/hashicorp/memberlist	16.493s
PASS
ok  	github.com/hashicorp/memberlist/internal/retry	0.217s
```

Look at https://github.com/grafana/dskit/pull/800 to see why I need this change.
