### PR TITLE
Move logging outside msgQueueLock critical section

### DIFF
--- a/net.go
+++ b/net.go
@@ -460,17 +460,22 @@ func (m *Memberlist) handleCommand(buf []byte, from net.Addr, timestamp time.Tim
 
 		// Check for overflow and append if not full
 		m.msgQueueLock.Lock()
-		if queue.Len() >= m.config.HandoffQueueDepth {
-			m.logger.Printf("[WARN] memberlist: handler queue full, dropping message (%d) %s", msgType, LogAddress(from))
-		} else {
+		dropped := queue.Len() >= m.config.HandoffQueueDepth
+		if !dropped {
 			queue.PushBack(msgHandoff{msgType, buf, from})
 		}
 		m.msgQueueLock.Unlock()
 
-		// Notify of pending message
-		select {
-		case m.handoffCh <- struct{}{}:
-		default:
+		if dropped {
+			// Log outside the lock to avoid blocking other goroutines (e.g. getNextMessage)
+			// on potentially slow I/O while holding msgQueueLock.
+			m.logger.Printf("[WARN] memberlist: handler queue full, dropping message (%d) %s", msgType, LogAddress(from))
+		} else {
+			// Notify of pending message
+			select {
+			case m.handoffCh <- struct{}{}:
+			default:
+			}
 		}
 
 	default:


### PR DESCRIPTION
I'm investigating some cases of `memberlist: handler queue full, dropping message`. While reviewing the code I noticed a thing I would like to improve.

`m.logger.Printf()` was called while holding `m.msgQueueLock` in the packet handler's "queue full" path. Logging can block (e.g. on I/O, slow writers, or contention inside the logger itself), so holding a mutex across a log call unnecessarily extends the critical section and increases the chance of stalling other goroutines that need the same lock — in particular `getNextMessage()`, which is on the hot path for draining the handoff queue.

This change captures the "dropped" condition under the lock and moves the log call to after `Unlock()`, keeping the critical section as short as possible.
